### PR TITLE
Py3 support

### DIFF
--- a/classproperties/__init__.py
+++ b/classproperties/__init__.py
@@ -1,6 +1,8 @@
 __author__ = 'dpepper'
 __version__ = '0.1.3'
 
+import sys
+
 
 class classproperty(object):
   def __init__(self, func):
@@ -9,7 +11,12 @@ class classproperty(object):
   def __get__(self, obj, objtype):
     args = []
 
-    if self.func.func_code.co_argcount > 0:
+    if sys.version_info[0] == 2:
+      code = self.func.func_code
+    else:
+      code = self.func.__code__
+
+    if code.co_argcount > 0:
       args.append(objtype)
 
     return self.func(*args)

--- a/tests/Test.py
+++ b/tests/Test.py
@@ -21,17 +21,17 @@ class ArrayTest(unittest.TestCase):
                 return 'q'
 
 
-        self.assertEquals(
+        self.assertEqual(
             Bar.p,
             'p'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             Bar().p,
             'p'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             Bar.q,
             'q'
         )
@@ -53,22 +53,22 @@ class ArrayTest(unittest.TestCase):
                 return 'd'
 
 
-        self.assertEquals(
+        self.assertEqual(
             Foo.a,
             'a'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             Foo.b(),
             'b'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             Foo.c(),
             'c'
         )
 
-        self.assertEquals(
+        self.assertEqual(
             Foo().d(),
             'd'
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+    py27,
+    py34,
+    py35,
+    py36
+
+[testenv]
+usedevelop = True
+setenv =
+   LANG=en_US.UTF-8
+   LANGUAGE=en_US:en
+   LC_ALL=en_US.UTF-8
+commands =
+   python setup.py test


### PR DESCRIPTION
Adding python3 support (and tox.ini to run tests on multiple python versions).

I'm trying to use `sqlalchemy_lightening` in a python3 project, and the query class hookup is broken because the classproperty code doesn't run in python 3.

Probably setup.py should be updated as well, but I'm not enough of an expert on that.


The error as bubbled up if classproperties is used with python3:
```
classproperties/__init__.py", line 12, in __get__
    if self.func.func_code.co_argcount > 0:
AttributeError: 'function' object has no attribute 'func_code'
```